### PR TITLE
pin gevent to < 22

### DIFF
--- a/RLBotGUIX main exe/RLBotGUIX.bat
+++ b/RLBotGUIX main exe/RLBotGUIX.bat
@@ -28,6 +28,7 @@ if %errorlevel% == 0 (
 
   %rl_py% -m pip install -U pip --no-warn-script-location
   %rl_pip% install setuptools wheel --no-warn-script-location
+  %rl_pip% install gevent^<22 --no-warn-script-location
   %rl_pip% install eel --no-warn-script-location
   %rl_pip% install -U rlbot_gui rlbot --no-warn-script-location
 ) else (


### PR DESCRIPTION
Fixes an issue with greenlet 2, pinning gevent to < 22 also causes greenlet to pin to < 2.

Greenelt 2 causes issues if the C++ redistributable is not present on a client machine and will cause RLBotGUI to not run.